### PR TITLE
fix(argocd): solve allow_empty error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,8 +68,9 @@ resource "argocd_application" "this" {
 
     sync_policy {
       automated = {
-        prune     = true
-        self_heal = true
+        allow_empty = false
+        prune       = true
+        self_heal   = true
       }
 
       sync_options = [


### PR DESCRIPTION
This solves the problem `terraform apply` always wanting to do some changes despite not having modifying the code. This happened because after applying, Argo CD added the `allow_empty` configuration but then Terraform would want to remove it because it is not explicitly configured.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.efs.argocd_application.this will be updated in-place
  ~ resource "argocd_application" "this" {
        id      = "efs-csi-driver"
        # (2 unchanged attributes hidden)

      ~ spec {
            # (2 unchanged attributes hidden)

          ~ sync_policy {
              ~ automated    = {
                  - "allow_empty" = false -> null
                    # (2 unchanged elements hidden)
                }
                # (1 unchanged attribute hidden)
            }

            # (2 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.helloworld.argocd_application.this will be updated in-place
  ~ resource "argocd_application" "this" {
        id      = "apps"
        # (2 unchanged attributes hidden)

      ~ spec {
            # (2 unchanged attributes hidden)

          ~ sync_policy {
              ~ automated    = {
                  - "allow_empty" = false -> null
                    # (2 unchanged elements hidden)
                }
                # (1 unchanged attribute hidden)
            }

            # (2 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:
``` 