### PR TITLE
fix: readd support to deactivate auto-sync which was broken by #26

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -284,7 +284,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.2.6"`
+Default: `"v2.0.0"`
 
 ==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
 
@@ -396,8 +396,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources
@@ -427,7 +427,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.2.6"`
+|`"v2.0.0"`
 |no
 
 |[[input_app_autosync]] <<input_app_autosync,app_autosync>>

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "argocd_project" "this" {
       ["https://github.com/camptocamp/devops-stack-module-applicationset.git"]
     )
 
-    destination {
+    destination { # TODO Variabilize these values
       name      = "in-cluster"
       namespace = var.project_dest_namespace
     }
@@ -47,9 +47,9 @@ resource "argocd_project" "this" {
     # This destination block is needed in order to allow the ApplicationSet below to be created in the namespace
     # `argocd` while belonging to this project. This block is only needed if the user provides a namespace above
     # instead of the wildcard "*" configured by default.
-    destination {
+    destination { # TODO Variabilize these values
       name      = "in-cluster"
-      namespace = "argocd"
+      namespace = var.argocd_namespace
     }
 
     orphaned_resources {
@@ -103,16 +103,19 @@ resource "argocd_application" "this" {
       }
     }
 
-    destination {
+    destination { # TODO Variabilize these values
       name      = "in-cluster"
       namespace = var.argocd_namespace
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #26. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)
- [x] KinD