### PR TITLE
fix!: remove the Argo CD namespace variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -229,9 +229,9 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -270,21 +270,13 @@ Type: `any`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.1.1"`
 
 ==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
 
@@ -420,8 +412,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources
@@ -442,16 +434,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.1.1"`
 |no
 
 |[[input_app_autosync]] <<input_app_autosync,app_autosync>>

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "argocd_repository" "private_ssh_repo" {
 resource "argocd_project" "this" {
   metadata {
     name      = var.name
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 
   spec {
@@ -50,7 +50,7 @@ resource "argocd_project" "this" {
     destination {
       name      = var.project_appset_dest_cluster_address == null ? var.project_appset_dest_cluster_name : null
       server    = var.project_appset_dest_cluster_address == null ? null : var.project_appset_dest_cluster_address
-      namespace = var.argocd_namespace
+      namespace = "argocd"
     }
 
     orphaned_resources {
@@ -67,7 +67,7 @@ resource "argocd_project" "this" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.name
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 
   timeouts {
@@ -107,7 +107,7 @@ resource "argocd_application" "this" {
     destination {
       name      = var.project_appset_dest_cluster_address == null ? var.project_appset_dest_cluster_name : null
       server    = var.project_appset_dest_cluster_address == null ? null : var.project_appset_dest_cluster_address
-      namespace = var.argocd_namespace
+      namespace = "argocd"
     }
 
     sync_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 ## Standard variables
 #######################
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

## Breaking change

- [x] Yes (in the module itself): because we removed the `argocd_namespace` variable

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)