### PR TITLE
feat!: point the Argo CD provider to the new repository

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -225,7 +225,7 @@ As this is an application, it needs to be deployed after the deployment of Argo 
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 6)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -235,18 +235,18 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_null]] <<provider_null,null>> (>= 3)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
 
 === Resources
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] (resource)
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] (resource)
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/repository[argocd_repository.private_https_repo] (resource)
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/repository[argocd_repository.private_ssh_repo] (resource)
+- https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/application[argocd_application.this] (resource)
+- https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/project[argocd_project.this] (resource)
+- https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/repository[argocd_repository.private_https_repo] (resource)
+- https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/repository[argocd_repository.private_ssh_repo] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
 
@@ -408,7 +408,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 6
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -419,7 +419,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |===
 
 = Resources
@@ -427,10 +427,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] |resource
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] |resource
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/repository[argocd_repository.private_https_repo] |resource
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/repository[argocd_repository.private_ssh_repo] |resource
+|https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/application[argocd_application.this] |resource
+|https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/project[argocd_project.this] |resource
+|https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/repository[argocd_repository.private_https_repo] |resource
+|https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/repository[argocd_repository.private_ssh_repo] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
 |===

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     argocd = {
-      source  = "oboukili/argocd"
-      version = ">= 5"
+      source  = "argoproj-labs/argocd"
+      version = ">= 6"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

About two months ago, the Argo CD provider we use was moved under the umbrella of `argoproj-labs`. The move is now completed and the provider will no longer be available under `oboukili/argocd` but instead `argoproj-labs/argocd` . Version 6.2.0 of the provider is available under both, but they released v7.0.0 last week to finalize the migration.

Note the following:
- the v7 does not contain any changes to the API and serves only to mark the end of the move;
- the GPG key used to sign the provider is no longer the personal one from oboukili but instead the one from the argoproj-labs;
- the migration guide is [here](https://github.com/argoproj-labs/terraform-provider-argocd?tab=readme-ov-file#migrate-provider-source-oboukili---argoproj-labs);
- the release notes are [here](https://github.com/argoproj-labs/terraform-provider-argocd/releases/tag/v7.0.0);

## Breaking change

- [x] Yes: I've marked this as a breaking change because this upgrade will require that the users **upgrade all their modules at the same time**.

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] KinD
- [x] SKS (Exoscale)
